### PR TITLE
make qrcode unique

### DIFF
--- a/baton-lib/Cargo.toml
+++ b/baton-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baton-lib"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Mike Moran <mike@houseofmoran.com>"]
 edition = "2018"
 

--- a/baton-lib/src/lib.rs
+++ b/baton-lib/src/lib.rs
@@ -41,16 +41,17 @@ impl QrCodeGenerator {
 
     pub fn as_data_uri(
         &self,
-        dark_color_hex: String,
-        light_color_hex: String,
+        foreground_color_hex: String,
+        background_color_hex: String,
     ) -> Result<String, JsValue> {
-        let dark_color = hex_color(&dark_color_hex).unwrap();
-        let light_color = hex_color(&light_color_hex).unwrap();
-        let code = QrCode::new(b"01234567").unwrap();
+        let foreground_color = hex_color(&foreground_color_hex).unwrap();
+        let background_color = hex_color(&background_color_hex).unwrap();
+        let message = format!("{}-{}", background_color_hex, foreground_color_hex);
+        let code = QrCode::new(message.to_string().into_bytes()).unwrap();
         let image = code
             .render::<Rgba<u8>>()
-            .dark_color(dark_color)
-            .light_color(light_color)
+            .dark_color(foreground_color)
+            .light_color(background_color)
             .max_dimensions(self.width as u32, self.height as u32)
             .build();
         let rescaled_image = resize(

--- a/view/package-lock.json
+++ b/view/package-lock.json
@@ -1781,9 +1781,9 @@
       }
     },
     "@mike_moran/baton-lib": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@mike_moran/baton-lib/-/baton-lib-0.5.1.tgz",
-      "integrity": "sha512-e6rHgh2YWRh7Jhv/dFMlQWsDcT9ssS76A39qaqF0nMkG9Jpffb+e24FnhHOidfjyXi43TNg3pIU1PsjpRfBQQQ=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mike_moran/baton-lib/-/baton-lib-0.6.0.tgz",
+      "integrity": "sha512-6a6d7/iDK5AgYsOlVlIQr3d8zwxR+yAG5iJFxdyRKq834ziCjuj18B54mqHtcgY2A6tL2sXdevz2ZwMKod5oVA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",

--- a/view/package.json
+++ b/view/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@mike_moran/baton-lib": "^0.5.1",
+    "@mike_moran/baton-lib": "^0.6.0",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.1.2",
     "@testing-library/user-event": "^12.2.2",


### PR DESCRIPTION
when same qrcode message is re-used this leads to the same pattern and iOS camera app appears not to re-show a qrcode if it is the same (which makes sense). so, make the message be based on the bg/fg values to make it unique